### PR TITLE
Mudança de domínio: www.fernandoike.com.br

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -135,7 +135,7 @@ github = https://github.com/wsilva
 twitter = https://twitter.com/_wsilva
 facebook = https://www.facebook.com/silva.tom
 
-[https://www.fernandoike.com/tags/devops/index.xml]
+[https://www.fernandoike.com.br/tags/devops/index.xml]
 name = Fernando (fike) Ike
 face = fernandoike.png
 github = https://github.com/fike


### PR DESCRIPTION
Trocando o domínio do meu site. De www.fernandoike.com para www.fernandoike.com.br